### PR TITLE
Update runtime to 25.08

### DIFF
--- a/one.jwr.interstellar.yaml
+++ b/one.jwr.interstellar.yaml
@@ -1,6 +1,6 @@
 id: one.jwr.interstellar
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: interstellar
 finish-args:
@@ -10,13 +10,6 @@ finish-args:
   - --share=network
   - --share=ipc
   - --device=dri
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    version: '24.08'
-    add-ld-path: .
-cleanup-commands:
-  - mkdir -p /app/lib/ffmpeg
 modules:
   - name: libmpv
     cleanup:


### PR DESCRIPTION
Also, drop the ffmpeg extension 

> This is supposed to ship in Freedesktop SDK 25.08. The major change for app developers is that there is no longer any need to have something like 

Source: https://bbhtt.in/posts/closing-the-chapter-on-openh264/